### PR TITLE
docs: :memo: Added missing import in type-definitions

### DIFF
--- a/website/docs/essentials/resolvers.mdx
+++ b/website/docs/essentials/resolvers.mdx
@@ -64,6 +64,7 @@ Next, use it to load your files dynamically:
 import MyQueryType from './query.type.graphql'
 import { createModule } from 'graphql-modules'
 import { loadFilesSync } from '@graphql-tools/load-files'
+import { join } from 'path'
 
 export const myModule = createModule({
   id: 'my-module',

--- a/website/docs/essentials/type-definitions.mdx
+++ b/website/docs/essentials/type-definitions.mdx
@@ -68,6 +68,7 @@ Next, use it to load your files dynamically:
 import MyQueryType from './query.type.graphql'
 import { createModule } from 'graphql-modules'
 import { loadFilesSync } from '@graphql-tools/load-files'
+import { join } from 'path'
 
 export const myModule = createModule({
   id: 'my-module',


### PR DESCRIPTION
## Description
Added missing import in type definitions section of the documentation

Fixes # 2106

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change is a documentation update
